### PR TITLE
Wifi config method changed

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -174,7 +174,7 @@ local function wifiSetup()
         debugPrint(0, "Wi-Fi: got IP " .. T.IP)
         mqttScheduleReconnect()
     end)
-    wifi.sta.config(ap_ssid, ap_pass)
+    wifi.sta.config {ssid=ap_ssid, pwd=ap_pass}
 end
 
 -- Main program entry point


### PR DESCRIPTION
wifi.sta.config("SSSID","PASSWORD") is depricated in current versions of NodeMCU Firmware, new method applied: wifi.sta.config {ssid="SSSID", pwd="Password"}

See: https://github.com/nodemcu/nodemcu-firmware/issues/2082